### PR TITLE
Check device existence

### DIFF
--- a/server.go
+++ b/server.go
@@ -45,10 +45,18 @@ type HostDevicePlugin struct {
 func NewHostDevicePlugin(config HostDevicePluginConfig) *HostDevicePlugin {
 	var devs = make([]*pluginapi.Device, config.NumDevices)
 
+	health := pluginapi.Healthy
+	for _, device := range config.HostDevices {
+		if _, err := os.Stat(device.HostPath); os.IsNotExist(err) {
+			health = pluginapi.Unhealthy
+			log.Println("HostPath '%s' is not found.", device.HostPath)
+		}
+	}
+
 	for i, _ := range devs {
 		devs[i] = &pluginapi.Device{
 			ID:     fmt.Sprint(i),
-			Health: pluginapi.Healthy,
+			Health: health,
 		}
 	}
 


### PR DESCRIPTION
I found a problem that a pod w/ host device resources can get deployed to a node thanks to this device plugin but failed to use it if the node actually doesn't have the device. I made it unhealthy. We still need to dynamically change the health by device existence changes.