### PR TITLE
Give an error on non-existing devices

### DIFF
--- a/hostdevice.go
+++ b/hostdevice.go
@@ -48,6 +48,9 @@ func (d HostDevice) Expand() ([]*ExpandedHostDevice, error) {
 	if err != nil {
 		return nil, err
 	}
+	if len(matchedHostPath) == 0 {
+		return nil, fmt.Errorf("no file matched: %s", d.HostPath)
+	}
 
 	expanded := []*ExpandedHostDevice{}
 	baseHostPath := strings.Split(d.HostPath, "*")[0]

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ func main() {
 	log.Println("Starting FS watcher.")
 	watcher, err := newFSWatcher(pluginapi.DevicePluginPath)
 	if err != nil {
-		log.Println("Failed to created FS watcher.")
+		log.Printf("Failed to created FS watcher: %v", err)
 		os.Exit(1)
 	}
 	defer watcher.Close()
@@ -34,7 +34,7 @@ func main() {
 	log.Println("Reading /k8s-host-device-plugin/config.json")
 	raw, err := ioutil.ReadFile(ConfigFilePath)
 	if err != nil {
-		fmt.Println(err.Error())
+		log.Printf("Fatal error reading config file: %v", err)
 		os.Exit(1)
 	}
 
@@ -56,7 +56,7 @@ L:
 
 			devicePlugin, err = NewHostDevicePlugin(config)
 			if err != nil {
-				fmt.Println(err.Error())
+				log.Printf("Fatal error configuring host device: %v", err)
 				os.Exit(1)
 			}
 			expandedHostDevicesStr := []string{}


### PR DESCRIPTION
### Describe what this PR does ###

This PR will return a fatal error during startup if the configuration doesn't match any devices.

### Does this pull request fix one issue? ###

Fixes https://github.com/everpeace/k8s-host-device-plugin/issues/15